### PR TITLE
Docker file and VD command work without xhost +

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 #  Ubuntu 20.04 LTS Focal Fossa installs TexLive 2019
 FROM ubuntu:focal
 MAINTAINER Ulrich Hoffmann <uho@xlerb.de>
+ENV XAUTHORITY /tmp/.Xauthority
+ENV LANG de_DE.UTF-8
 
 RUN ln -snf /usr/share/zoneinfo/Etc/UTC /etc/localtime \
     && echo "Etc/UTC" > /etc/timezone \

--- a/vd
+++ b/vd
@@ -49,7 +49,6 @@ echo
 exit
 fi
 
-xhost +
 set -x
 docker run -i -t \
   -e USER=$USER \
@@ -58,9 +57,9 @@ docker run -i -t \
   --name docker-vd \
   -v /tmp/.X11-unix/:/tmp/.X11-unix/ \
   -v "$vd_home":/VierteDimension \
+  -v /dev/dri:/dev/dri -v $XAUTHORITY:/tmp/.Xauthority \
   --rm \
   $docker_image $*
-xhost -
 
 
 # Original:


### PR DESCRIPTION
Mit diesem Patch braucht man kein xhost + mehr, um vom Docker auf X zuzugreifen; außerdem können die verwendeten Programme via OpenGL rendern, was deutlich performanter ist.